### PR TITLE
Update peripherial access crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,40 +23,35 @@ smart-default = "0.6.0"
 paste = "0.1.18"
 typenum = { version = "1.12", features = ["no_std"] }
 
-[dependencies.atsamd51j19a]
-version = "0.6.0"
+[dependencies.atsamd51j]
+version = "0.8.0"
 optional = true
 
-[dependencies.atsamd51j20a]
-version = "0.6.0"
+[dependencies.atsamd51g]
+version = "0.8.0"
 optional = true
 
-[dependencies.atsamd51g19a]
-version = "0.6.0"
+[dependencies.atsamd21g]
+version = "0.8.0"
 optional = true
 
-[dependencies.atsamd21g18a]
-version = "0.6.0"
+[dependencies.atsamd21e]
+version = "0.8.0"
 optional = true
 
-[dependencies.atsamd21e18a]
-version = "0.6.0"
-optional = true
-
-[dependencies.atsamd21j18a]
-version = "0.6.0"
+[dependencies.atsamd21j]
+version = "0.8.0"
 optional = true
 
 [features]
 samd21 = []
-samd21g18a = ["samd21", "atsamd21g18a"]
-samd21e18a = ["samd21", "atsamd21e18a"]
-samd21j18a = ["samd21", "atsamd21j18a"]
+samd21g = ["samd21", "atsamd21g"]
+samd21e = ["samd21", "atsamd21e"]
+samd21j = ["samd21", "atsamd21j"]
 samd5x = []
-samd51j19a = ["samd5x", "atsamd51j19a"]
-samd51j20a = ["samd5x", "atsamd51j20a"]
-samd51g19a = ["samd5x", "atsamd51g19a"]
+samd51j = ["samd5x", "atsamd51j"]
+samd51g = ["samd5x", "atsamd51g"]
 
 [[example]]
 name = "simple"
-required-features = ["samd21j18a"]
+required-features = ["samd21j"]

--- a/Justfile
+++ b/Justfile
@@ -1,8 +1,8 @@
-features := "samd21g18a samd21e18a samd21j18a samd51j19a samd51j20a samd51g19a"
+features := "samd21g samd21e samd21j samd51j samd51g"
 
 check:
-    cargo check --features samd51j19a
-    cargo check --features samd21j18a
+    cargo check --features samd51j
+    cargo check --features samd21j
 
 release version:
     git diff HEAD --exit-code --name-only
@@ -20,7 +20,7 @@ release version:
 
 build-docs:
     cargo clean --doc
-    cargo doc --no-deps --features samd21g18a
+    cargo doc --no-deps --features samd21g
     rsync -r --no-times --checksum --delete --exclude samd_dma/ --exclude .lock --exclude _config.yml target/doc/ docs
     for feature in {{features}}; do \
         cargo doc --no-deps --features $feature ; \

--- a/README.tpl
+++ b/README.tpl
@@ -14,12 +14,11 @@ The following feature flags control which MCU variant you are targeting.
 
 | Name (Docs) | # DMA Channels | Boards |
 |:------|:----|:-----------------------|
-| [samd21g18a](https://proman21.github.io/samd-dma/samd21g18a/index.html) | 12 | Circuit Playground Express, Feather M0, Metro M0, MKR ZERO, SAMD21 Mini, SODAQ ONE |
-| [samd21e18a](https://proman21.github.io/samd-dma/samd21e18a/index.html) | 12 | Gemma M0, Trinket M0, Serpente |
-| [samd21j18a](https://proman21.github.io/samd-dma/samd21j18a/index.html) | 12 | SODAQ SARA AFF |
-| [samd51j19a](https://proman21.github.io/samd-dma/samd51j19a/index.html) | 32 | EdgeBadge, Feather M4, Metro M4 |
-| [samd51j20a](https://proman21.github.io/samd-dma/samd51j20a/index.html) | 32 | PyPortal |
-| [samd51g19a](https://proman21.github.io/samd-dma/samd51g19a/index.html) | 32 | ItsyBitsy M4, Trellis M4 |
+| [samd21g](https://proman21.github.io/samd-dma/samd21g/index.html) | 12 | Circuit Playground Express, Feather M0, Metro M0, MKR ZERO, SAMD21 Mini, SODAQ ONE |
+| [samd21e](https://proman21.github.io/samd-dma/samd21e/index.html) | 12 | Gemma M0, Trinket M0, Serpente |
+| [samd21j](https://proman21.github.io/samd-dma/samd21j/index.html) | 12 | SODAQ SARA AFF |
+| [samd51j](https://proman21.github.io/samd-dma/samd51j/index.html) | 32 | EdgeBadge, Feather M4, Metro M4, PyPortal |
+| [samd51g](https://proman21.github.io/samd-dma/samd51g/index.html) | 32 | ItsyBitsy M4, Trellis M4 |
 
 ## About
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -7,44 +7,9 @@ use crate::descriptors::{TransferDescriptor};
 
 #[cfg(feature = "samd5x")]
 macro_rules! channel_reg {
-    (@arm $reg:ident, $n:literal) => {
-        paste::expr! { unsafe { &(*DMAC::ptr()).[<$reg $n>] } }
-    };
     ($reg:ident, $n:expr) => {
-        match $n {
-            0 => channel_reg!(@arm $reg, 0),
-            1 => channel_reg!(@arm $reg, 1),
-            2 => channel_reg!(@arm $reg, 2),
-            3 => channel_reg!(@arm $reg, 3),
-            4 => channel_reg!(@arm $reg, 4),
-            5 => channel_reg!(@arm $reg, 5),
-            6 => channel_reg!(@arm $reg, 6),
-            7 => channel_reg!(@arm $reg, 7),
-            8 => channel_reg!(@arm $reg, 8),
-            9 => channel_reg!(@arm $reg, 9),
-            10 => channel_reg!(@arm $reg, 10),
-            11 => channel_reg!(@arm $reg, 11),
-            12 => channel_reg!(@arm $reg, 12),
-            13 => channel_reg!(@arm $reg, 13),
-            14 => channel_reg!(@arm $reg, 14),
-            15 => channel_reg!(@arm $reg, 15),
-            16 => channel_reg!(@arm $reg, 16),
-            17 => channel_reg!(@arm $reg, 17),
-            18 => channel_reg!(@arm $reg, 18),
-            19 => channel_reg!(@arm $reg, 19),
-            20 => channel_reg!(@arm $reg, 20),
-            21 => channel_reg!(@arm $reg, 21),
-            22 => channel_reg!(@arm $reg, 22),
-            23 => channel_reg!(@arm $reg, 23),
-            24 => channel_reg!(@arm $reg, 24),
-            25 => channel_reg!(@arm $reg, 25),
-            26 => channel_reg!(@arm $reg, 26),
-            27 => channel_reg!(@arm $reg, 27),
-            28 => channel_reg!(@arm $reg, 28),
-            29 => channel_reg!(@arm $reg, 29),
-            30 => channel_reg!(@arm $reg, 30),
-            31 => channel_reg!(@arm $reg, 31),
-            _ => unreachable!()
+        unsafe {
+            &(&*DMAC::ptr()).channel[$n as usize].$reg
         }
     };
 }
@@ -196,7 +161,7 @@ impl Channel {
     /// Set the priority level of the channel.
     pub fn set_priority(&mut self, priority: Priority) {
         #[cfg(feature = "samd5x")]
-        channel_reg!(chprilvl, self.id).write(|w| unsafe { w.prilvl().bits(priority as u8) });
+        channel_reg!(chprilvl, self.id).write(|w| w.prilvl().bits(priority as u8));
         #[cfg(feature = "samd21")]
         channel_reg!(chctrlb, self.id).modify(|_, w| w.lvl().bits(priority as u8))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,23 +27,20 @@ compile_error!("Please use this crate's feature flags to select a SAM micro-cont
 extern crate bitflags;
 extern crate smart_default;
 
-#[cfg(feature = "samd51j19a")]
-use atsamd51j19a as target_device;
+#[cfg(feature = "samd51j")]
+use atsamd51j as target_device;
 
-#[cfg(feature = "samd51j20a")]
-use atsamd51j20a as target_device;
+#[cfg(feature = "samd51g")]
+use atsamd51g as target_device;
 
-#[cfg(feature = "samd51g19a")]
-use atsamd51g19a as target_device;
+#[cfg(feature = "samd21g")]
+use atsamd21g as target_device;
 
-#[cfg(feature = "samd21g18a")]
-use atsamd21g18a as target_device;
+#[cfg(feature = "samd21e")]
+use atsamd21e as target_device;
 
-#[cfg(feature = "samd21e18a")]
-use atsamd21e18a as target_device;
-
-#[cfg(feature = "samd21j18a")]
-use atsamd21j18a as target_device;
+#[cfg(feature = "samd21j")]
+use atsamd21j as target_device;
 
 mod channel;
 mod types;

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,9 +3,9 @@ use smart_default::SmartDefault;
 
 use crate::target_device::generic::Variant;
 #[cfg(feature = "samd5x")]
-use crate::target_device::dmac::chctrla::{TRIGACT_A, BURSTLEN_A, THRESHOLD_A, TRIGSRC_A};
+use crate::target_device::dmac::channel::chctrla::{TRIGACT_A, BURSTLEN_A, THRESHOLD_A, TRIGSRC_A};
 #[cfg(feature = "samd5x")]
-use crate::target_device::dmac::chprilvl::PRILVL_A;
+use crate::target_device::dmac::channel::chprilvl::PRILVL_A;
 #[cfg(feature = "samd5x")]
 use crate::target_device::dmac::prictrl0::{QOS0_A, QOS1_A, QOS2_A, QOS3_A};
 #[cfg(feature = "samd21")]
@@ -97,22 +97,6 @@ pub enum Priority {
     Level3,
 }
 
-#[cfg(feature = "samd5x")]
-impl From<Variant<u8, PRILVL_A>> for Priority {
-    fn from(value: Variant<u8, PRILVL_A>) -> Priority {
-        use self::PRILVL_A::*;
-        use self::Priority::*;
-        match value {
-            Variant::Val(LVL0) => Level0,
-            Variant::Val(LVL1) => Level1,
-            Variant::Val(LVL2) => Level2,
-            Variant::Val(LVL3) => Level3,
-            _ => Level0,
-        }
-    }
-}
-
-#[cfg(feature = "samd21")]
 impl From<PRILVL_A> for Priority {
     fn from(value: PRILVL_A) -> Priority {
         use self::PRILVL_A::*;


### PR DESCRIPTION
The variants of the devices with different memory sizes have been combined into the same crate in the latest versions, so I had to update this crate to match. This changes the available features, so it probably deserves a minor release.

I also made some changes that were needed due to upstream refactoring.

I have tested that this compiles for all device variants, but have only done runtime testing with a samd21e18a.